### PR TITLE
fusumaCropImage bollean doesn't mean a scale

### DIFF
--- a/Sources/FSCameraVC.swift
+++ b/Sources/FSCameraVC.swift
@@ -169,7 +169,7 @@ public class FSCameraVC: UIViewController, UIGestureRecognizerDelegate {
                     let imageRef = image.cgImage?.cropping(to: CGRect(x: rcy-iw*0.5, y: 0 , width: iw, height: iw))
                     DispatchQueue.main.async() {
                         if fusumaCropImage {
-                            var resizedImage = UIImage(cgImage: imageRef!, scale: sw/iw, orientation: image.imageOrientation)
+                            var resizedImage = UIImage(cgImage: imageRef!, scale: 1.0, orientation: image.imageOrientation)
                             if let device = self.device, let cgImg =  resizedImage.cgImage, device.position == .front {
                                 func flipImage(image: UIImage!) -> UIImage! {
                                     let imageSize:CGSize = image.size


### PR DESCRIPTION
Do not understand it, if the image is lower than previewViewContainer the resizedImage will be smaller.
If the image is bigger than previewViewContainer the resizedImage will be bigger.